### PR TITLE
Add React Native project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 **Website:** [https://prasenjeet-symon.github.io/shipli-ai/](https://prasenjeet-symon.github.io/shipli-ai/)
 
-Store rejections cost days of development time. **Shipli** is a CLI tool that audits your Flutter source code against **Apple App Store** and **Google Play** guidelines using AI.
+Store rejections cost days of development time. **Shipli** is a CLI tool that audits your Flutter and React Native source code against **Apple App Store** and **Google Play** guidelines using AI.
 
 Catch missing permissions, policy violations, and compliance issues before you submit.
 
@@ -16,7 +16,7 @@ Catch missing permissions, policy violations, and compliance issues before you s
 - **AI-Powered** — Choose between Google Gemini or Anthropic Claude. Bring your own API key.
 - **Up-to-Date Policies** — Ships with the latest Apple and Google Play store policies. Works offline.
 - **Auto-Detection** — Automatically detects project type and target platform from your project structure.
-- **Zero Setup** — No compiled artifacts needed. Point it at your Flutter project and run.
+- **Zero Setup** — No compiled artifacts needed. Point it at your Flutter or React Native project and run.
 - **CI-Ready** — Designed for automation. Integrates with any CI/CD pipeline.
 
 ## Installation
@@ -60,7 +60,7 @@ shipli --dir ./ --mode code
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `--dir <path>` | Path to Flutter project root | *required* |
+| `--dir <path>` | Path to Flutter or React Native project root | *required* |
 | `--key <key>` | API key | `.shipli` / env var |
 | `--provider <name>` | `gemini` or `claude` | `gemini` |
 | `--model <model>` | Model override | per provider |
@@ -118,6 +118,12 @@ Use `shipli config` to update settings anytime.
 |----------|---------|
 | Permissions & Data Safety | Unnecessary permissions, data safety declarations |
 | Data Collection & Privacy | Privacy policy, user data handling |
+
+## Supported Project Types
+
+- Flutter apps
+- Flutter packages/plugins
+- React Native apps
 | Content & Behavior | Restricted content, deceptive behavior |
 | Billing & Monetization | Payment method compliance |
 | API Level & Compatibility | Target API requirements, version compatibility |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prasenjeet/shipli",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@prasenjeet/shipli",
-      "version": "1.1.0",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
@@ -19,7 +19,8 @@
         "zod": "^4.3.6"
       },
       "bin": {
-        "shipli": "src/index.js"
+        "shipli": "src/index.js",
+        "shipli-mcp": "src/mcp-server.js"
       },
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
   "name": "@prasenjeet/shipli",
   "version": "1.3.0",
-  "description": "AI-powered App Store review audit for Flutter projects. Catch rejections before you submit.",
+  "description": "AI-powered App Store review audit for Flutter and React Native projects. Catch rejections before you submit.",
   "type": "module",
   "bin": {
     "shipli": "src/index.js",
     "shipli-mcp": "src/mcp-server.js"
+  },
+  "scripts": {
+    "test": "node --test tests/*.test.js"
   },
   "files": [
     "src",
@@ -16,6 +19,7 @@
   },
   "keywords": [
     "flutter",
+    "react-native",
     "app-store",
     "apple",
     "review",

--- a/src/auditor.js
+++ b/src/auditor.js
@@ -59,10 +59,11 @@ CODE QUALITY AUDIT CATEGORIES (evaluate each):
 
 // ── System prompt builders ──
 
-function buildStorePrompt(platform) {
+function buildStorePrompt(platform, ecosystem = 'flutter') {
   const isIos = platform === 'ios';
   const isAndroid = platform === 'android';
   const isBoth = platform === 'both';
+  const isReactNative = ecosystem === 'react-native';
 
   const guidelinesRef = [];
   if (isIos || isBoth) {
@@ -78,7 +79,7 @@ function buildStorePrompt(platform) {
       "- Apple's App Store Review Guidelines (all sections)",
       '- iOS privacy requirements (Info.plist usage descriptions, App Tracking Transparency)',
       '- In-app purchase requirements (StoreKit vs third-party payment)',
-      '- Common iOS rejection reasons for Flutter apps',
+      isReactNative ? '- Common iOS rejection reasons for React Native apps' : '- Common iOS rejection reasons for Flutter apps',
     );
   }
   if (isAndroid || isBoth) {
@@ -86,18 +87,30 @@ function buildStorePrompt(platform) {
       "- Google Play Developer Program Policies (all sections)",
       '- Android permissions model and Data Safety requirements',
       '- Google Play Billing Library requirements for digital goods',
-      '- Common Android rejection reasons for Flutter apps',
+      isReactNative ? '- Common Android rejection reasons for React Native apps' : '- Common Android rejection reasons for Flutter apps',
     );
+  }
+  if (isReactNative) {
+    knowledge.push(
+      '- React Native app structure, Metro bundling, and native bridge/module constraints',
+      '- React Navigation, OTA/code push risk areas, and React Native mobile permission flows',
+    );
+  } else {
+    knowledge.push('- Flutter app structure, widget lifecycle, and Flutter-specific platform integration');
   }
   knowledge.push(
     '- Data safety and encryption export compliance',
     '- Minimum functionality and content policy requirements',
   );
 
-  const evidence = ['- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies'];
+  const evidence = [isReactNative
+    ? '- "PACKAGE_JSON_METADATA": App name, version, npm dependencies, and scripts'
+    : '- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies'];
   if (isIos || isBoth) evidence.push('- "INFO_PLIST_PERMISSIONS": NS*UsageDescription keys from Info.plist');
   if (isAndroid || isBoth) evidence.push('- "ANDROID_MANIFEST_PERMISSIONS": uses-permission entries from AndroidManifest.xml');
-  evidence.push('- "DART_SKELETONS": Architectural skeleton of Dart files');
+  evidence.push(isReactNative
+    ? '- "JS_TS_SKELETONS": Architectural skeleton of JavaScript/TypeScript files'
+    : '- "DART_SKELETONS": Architectural skeleton of Dart files');
 
   const categories = [];
   if (isIos || isBoth) categories.push(IOS_STORE_CATEGORIES);
@@ -105,7 +118,7 @@ function buildStorePrompt(platform) {
 
   const platformLabel = isBoth ? 'Apple App Store and Google Play' : isIos ? 'Apple App Store' : 'Google Play Store';
 
-  return `You are an experienced ${platformLabel} reviewer conducting a pre-submission compliance audit of a Flutter/Dart application.
+  return `You are an experienced ${platformLabel} reviewer conducting a pre-submission compliance audit of a ${isReactNative ? 'React Native' : 'Flutter/Dart'} application.
 
 ${guidelinesRef.join('\n')}
 
@@ -120,28 +133,30 @@ ${categories.join('\n')}
 ${RESPONSE_FORMAT}`;
 }
 
-function buildCodePrompt() {
-  return `You are a senior Flutter/Dart software engineer conducting a code quality and security review. You have deep knowledge of:
+function buildCodePrompt(ecosystem = 'flutter') {
+  const isReactNative = ecosystem === 'react-native';
+  return `You are a senior ${isReactNative ? 'React Native/JavaScript/TypeScript' : 'Flutter/Dart'} software engineer conducting a code quality and security review. You have deep knowledge of:
 
-- Flutter best practices, widget lifecycle, state management patterns
-- Dart language features, null safety, async patterns
+- ${isReactNative ? 'React Native best practices, hooks, navigation, state management, and native module integration' : 'Flutter best practices, widget lifecycle, state management patterns'}
+- ${isReactNative ? 'JavaScript/TypeScript language features, async patterns, and React component architecture' : 'Dart language features, null safety, async patterns'}
 - Common security vulnerabilities in mobile apps (OWASP Mobile Top 10)
-- Performance optimization for Flutter (build methods, rebuilds, isolates)
-- Dependency management and pub.dev ecosystem health
+- ${isReactNative ? 'Performance optimization for React Native (bridge usage, list rendering, bundle size, memoization)' : 'Performance optimization for Flutter (build methods, rebuilds, isolates)'}
+- ${isReactNative ? 'Dependency management and npm ecosystem health' : 'Dependency management and pub.dev ecosystem health'}
 
 Focus ONLY on code quality, security, and engineering best practices — not store compliance or legal requirements.
 
 EVIDENCE FORMAT:
-- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies
-- "DART_SKELETONS": Architectural skeleton of Dart files
+${isReactNative ? '- "PACKAGE_JSON_METADATA": App name, version, npm dependencies, and scripts' : '- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies'}
+${isReactNative ? '- "JS_TS_SKELETONS": Architectural skeleton of JavaScript/TypeScript files' : '- "DART_SKELETONS": Architectural skeleton of Dart files'}
 ${CODE_CATEGORIES}
 ${RESPONSE_FORMAT}`;
 }
 
-function buildBothPrompt(platform) {
+function buildBothPrompt(platform, ecosystem = 'flutter') {
   const isIos = platform === 'ios';
   const isAndroid = platform === 'android';
   const isBoth = platform === 'both';
+  const isReactNative = ecosystem === 'react-native';
 
   const guidelinesRef = [];
   if (isIos || isBoth) {
@@ -167,15 +182,19 @@ function buildBothPrompt(platform) {
     );
   }
   knowledge.push(
-    '- Flutter best practices, widget lifecycle, state management patterns',
+    isReactNative ? '- React Native best practices, navigation, hooks, state management, and native bridge patterns' : '- Flutter best practices, widget lifecycle, state management patterns',
     '- Common security vulnerabilities in mobile apps (OWASP Mobile Top 10)',
-    '- Performance optimization and dependency management',
+    isReactNative ? '- React Native performance optimization and npm dependency management' : '- Performance optimization and dependency management',
   );
 
-  const evidence = ['- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies'];
+  const evidence = [isReactNative
+    ? '- "PACKAGE_JSON_METADATA": App name, version, npm dependencies, and scripts'
+    : '- "PUBSPEC_METADATA": App name, version, and list of pub.dev package dependencies'];
   if (isIos || isBoth) evidence.push('- "INFO_PLIST_PERMISSIONS": NS*UsageDescription keys from Info.plist');
   if (isAndroid || isBoth) evidence.push('- "ANDROID_MANIFEST_PERMISSIONS": uses-permission entries from AndroidManifest.xml');
-  evidence.push('- "DART_SKELETONS": Architectural skeleton of Dart files');
+  evidence.push(isReactNative
+    ? '- "JS_TS_SKELETONS": Architectural skeleton of JavaScript/TypeScript files'
+    : '- "DART_SKELETONS": Architectural skeleton of Dart files');
 
   const categories = [];
   if (isIos || isBoth) categories.push(IOS_STORE_CATEGORIES);
@@ -184,14 +203,14 @@ function buildBothPrompt(platform) {
 
   const platformLabel = isBoth ? 'Apple App Store and Google Play' : isIos ? 'Apple App Store' : 'Google Play Store';
 
-  return `You are an experienced ${platformLabel} reviewer AND senior Flutter/Dart engineer conducting a comprehensive audit.
+  return `You are an experienced ${platformLabel} reviewer AND senior ${isReactNative ? 'React Native/JavaScript/TypeScript' : 'Flutter/Dart'} engineer conducting a comprehensive audit.
 
 ${guidelinesRef.join('\n')}
 
 You have deep knowledge of:
 ${knowledge.join('\n')}
 
-Analyze the provided Flutter project evidence and produce a comprehensive audit report covering both store compliance and code quality.
+Analyze the provided ${isReactNative ? 'React Native' : 'Flutter'} project evidence and produce a comprehensive audit report covering both store compliance and code quality.
 
 EVIDENCE FORMAT:
 ${evidence.join('\n')}
@@ -277,23 +296,24 @@ ${RESPONSE_FORMAT}`;
 
 // ── Prompt selection ──
 
-function selectPrompt(projectType, mode, platform) {
+function selectPrompt(projectType, mode, platform, ecosystem = 'flutter') {
   if (projectType === 'package') {
     if (mode === 'store') return buildPkgStorePrompt();
     if (mode === 'code') return buildPkgCodePrompt();
     return buildPkgBothPrompt();
   }
   // App
-  if (mode === 'store') return buildStorePrompt(platform);
-  if (mode === 'code') return buildCodePrompt();
-  return buildBothPrompt(platform);
+  if (mode === 'store') return buildStorePrompt(platform, ecosystem);
+  if (mode === 'code') return buildCodePrompt(ecosystem);
+  return buildBothPrompt(platform, ecosystem);
 }
 
 // ── Message builder ──
 
-function buildUserMessage({ files, exampleFiles, permissions, androidPermissions, pubspec, plistFound, androidManifestFound, projectType, appleGuidelines, googleGuidelines }) {
+function buildUserMessage({ files, exampleFiles, permissions, androidPermissions, metadata, plistFound, androidManifestFound, projectType, appleGuidelines, googleGuidelines }) {
   const sections = [];
   const isPackage = projectType === 'package';
+  const isReactNative = metadata.ecosystem === 'react-native';
 
   // Inject live guidelines as grounding context
   if (appleGuidelines?.content) {
@@ -308,17 +328,20 @@ function buildUserMessage({ files, exampleFiles, permissions, androidPermissions
     sections.push(googleGuidelines.content);
   }
 
-  sections.push('\n=== PUBSPEC_METADATA ===');
-  sections.push(`${isPackage ? 'Package' : 'App'}: ${pubspec.name}${pubspec.version ? ` v${pubspec.version}` : ''}`);
-  if (pubspec.description) {
-    sections.push(`Description: ${pubspec.description}`);
+  sections.push(isReactNative ? '\n=== PACKAGE_JSON_METADATA ===' : '\n=== PUBSPEC_METADATA ===');
+  sections.push(`${isPackage ? 'Package' : 'App'}: ${metadata.name}${metadata.version ? ` v${metadata.version}` : ''}`);
+  if (metadata.description) {
+    sections.push(`Description: ${metadata.description}`);
   }
-  sections.push(`Dependencies: ${pubspec.dependencies.join(', ') || '(none)'}`);
-  sections.push(`Dev Dependencies: ${pubspec.devDependencies.join(', ') || '(none)'}`);
+  sections.push(`Dependencies: ${metadata.dependencies.join(', ') || '(none)'}`);
+  sections.push(`Dev Dependencies: ${metadata.devDependencies.join(', ') || '(none)'}`);
+  if (isReactNative) {
+    sections.push(`Scripts: ${metadata.scripts.join(', ') || '(none)'}`);
+  }
 
-  if (isPackage && pubspec.pluginPlatforms) {
+  if (isPackage && metadata.pluginPlatforms) {
     sections.push('\n=== PLUGIN_PLATFORMS ===');
-    for (const [platform, config] of Object.entries(pubspec.pluginPlatforms)) {
+    for (const [platform, config] of Object.entries(metadata.pluginPlatforms)) {
       sections.push(`${platform}: ${JSON.stringify(config)}`);
     }
   }
@@ -351,7 +374,7 @@ function buildUserMessage({ files, exampleFiles, permissions, androidPermissions
     }
   }
 
-  sections.push('\n=== DART_SKELETONS ===');
+  sections.push(isReactNative ? '\n=== JS_TS_SKELETONS ===' : '\n=== DART_SKELETONS ===');
   for (const file of files) {
     sections.push(`\n--- ${file.relativePath} ---`);
     sections.push(file.skeleton);
@@ -479,7 +502,7 @@ const TOKEN_LIMITS = {
 };
 
 export async function audit(evidence, { apiKey, model, provider, mode, platform }) {
-  const systemPrompt = selectPrompt(evidence.projectType, mode, platform);
+  const systemPrompt = selectPrompt(evidence.projectType, mode, platform, evidence.metadata.ecosystem);
   const userMessage = buildUserMessage(evidence);
 
   const estimated = {

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,23 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export const PROVIDER_DEFAULTS = {
+  claude: {
+    envKey: 'ANTHROPIC_API_KEY',
+    model: 'claude-sonnet-4-6',
+  },
+  gemini: {
+    envKey: 'GEMINI_API_KEY',
+    model: 'gemini-2.5-flash',
+  },
+};
+
+export function detectPlatform(projectDir) {
+  const hasIos = existsSync(join(projectDir, 'ios'));
+  const hasAndroid = existsSync(join(projectDir, 'android'));
+
+  if (hasIos && hasAndroid) return 'both';
+  if (hasIos) return 'ios';
+  if (hasAndroid) return 'android';
+  return 'both';
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
@@ -13,11 +12,11 @@ import { runInit, runConfig } from './init.js';
 import { scan } from './scanner.js';
 import { read as readPlist } from './plist-reader.js';
 import { read as readManifest } from './manifest-reader.js';
-import { read as readPubspec } from './pubspec-reader.js';
 import { audit } from './auditor.js';
 import { fetchGuidelines } from './guidelines.js';
 import { print as printReport } from './reporter.js';
 import { PROVIDER_DEFAULTS as DEFAULTS, detectPlatform } from './defaults.js';
+import { readProjectMetadata, validateProject } from './project-reader.js';
 import { trackEvent } from './telemetry.js';
 
 // Read package version
@@ -28,7 +27,7 @@ const program = new Command();
 
 program
   .name('shipli')
-  .description('AI-powered store review audit for Flutter projects')
+  .description('AI-powered store review audit for Flutter and React Native projects')
   .version(pkg.version);
 
 // Init subcommand
@@ -53,7 +52,7 @@ program
 program
   .command('audit', { isDefault: true })
   .description('Run the audit (default command)')
-  .requiredOption('--dir <path>', 'Path to Flutter project root')
+  .requiredOption('--dir <path>', 'Path to Flutter or React Native project root')
   .option('--key <apiKey>', 'API key (or set in .shipli / env var)')
   .option('--provider <provider>', 'AI provider: gemini or claude')
   .option('--model <model>', 'Model to use (defaults per provider)')
@@ -62,17 +61,6 @@ program
   .option('--platform <platform>', 'Target: ios, android, or both (auto-detected if omitted)')
   .action(async (opts) => {
     const projectDir = resolve(opts.dir);
-
-    // Validate directory
-    if (!existsSync(projectDir)) {
-      console.error(chalk.red(`Error: Directory not found: ${projectDir}`));
-      process.exit(1);
-    }
-
-    if (!existsSync(join(projectDir, 'lib'))) {
-      console.error(chalk.red(`Error: No lib/ directory found in ${projectDir}. Is this a Flutter project?`));
-      process.exit(1);
-    }
 
     // Load .shipli config (project-level > home-level)
     const config = await loadConfig(projectDir);
@@ -113,28 +101,31 @@ program
     }
 
     const platformLabel = { ios: 'iOS', android: 'Android', both: 'iOS + Android' }[platform];
-    let spinner = ora({ text: `Scanning Flutter project (${platformLabel})...`, color: 'cyan' }).start();
+    let spinner = ora({ text: `Scanning project (${platformLabel})...`, color: 'cyan' }).start();
     const startTime = Date.now();
 
     try {
-      // 1. Read pubspec.yaml first (needed for type detection)
-      spinner.text = 'Reading pubspec.yaml...';
-      const pubspec = await readPubspec(projectDir);
+      const validatedDir = validateProject(projectDir);
 
-      // 2. Resolve project type: CLI flag > config > auto-detect from pubspec
-      const projectType = opts.type || config.type || pubspec.projectType;
-      spinner.text = `Detected: ${chalk.cyan(projectType)} / ${chalk.cyan(platformLabel)}`;
+      // 1. Read project metadata first (needed for type detection)
+      spinner.text = 'Reading project metadata...';
+      const metadata = await readProjectMetadata(validatedDir);
 
-      // 3. Scan Dart files
-      spinner.text = 'Scanning Dart files...';
-      const { files, stats } = await scan(projectDir);
+      // 2. Resolve project type: CLI flag > config > auto-detect from metadata
+      const projectType = opts.type || config.type || metadata.projectType;
+      const ecosystemLabel = metadata.ecosystem === 'react-native' ? 'react-native' : 'flutter';
+      spinner.text = `Detected: ${chalk.cyan(projectType)} / ${chalk.cyan(ecosystemLabel)} / ${chalk.cyan(platformLabel)}`;
+
+      // 3. Scan source files
+      spinner.text = `Scanning ${metadata.ecosystem === 'react-native' ? 'JavaScript/TypeScript' : 'Dart'} files...`;
+      const { files, stats } = await scan(validatedDir, { ecosystem: metadata.ecosystem });
       spinner.text = `Scanned ${stats.totalFiles} files (${stats.totalLines} lines → ${stats.skeletonLines} skeleton lines)`;
 
       // 4. Scan example/ app for packages (if it exists)
       let exampleFiles = [];
-      if (projectType === 'package' && existsSync(join(projectDir, 'example', 'lib'))) {
+      if (projectType === 'package' && metadata.ecosystem === 'flutter' && existsSync(join(validatedDir, 'example', 'lib'))) {
         spinner.text = 'Scanning example/ app...';
-        const exampleResult = await scan(join(projectDir, 'example'));
+        const exampleResult = await scan(join(validatedDir, 'example'), { ecosystem: metadata.ecosystem });
         exampleFiles = exampleResult.files;
       }
 
@@ -144,12 +135,12 @@ program
 
       if (projectType === 'app' && (platform === 'ios' || platform === 'both')) {
         spinner.text = 'Reading Info.plist...';
-        plistData = await readPlist(projectDir);
+        plistData = await readPlist(validatedDir);
       }
 
       if (projectType === 'app' && (platform === 'android' || platform === 'both')) {
         spinner.text = 'Reading AndroidManifest.xml...';
-        manifestData = await readManifest(projectDir);
+        manifestData = await readManifest(validatedDir);
       }
 
       // 6. Load store guidelines (for store and both modes)
@@ -185,7 +176,7 @@ program
           exampleFiles,
           permissions: plistData.permissions,
           androidPermissions: manifestData.permissions,
-          pubspec,
+          metadata,
           plistFound: (platform === 'ios' || platform === 'both') ? plistData.found : undefined,
           androidManifestFound: (platform === 'android' || platform === 'both') ? manifestData.found : undefined,
           projectType,
@@ -200,7 +191,7 @@ program
       // 8. Print report
       printReport(result, {
         projectType,
-        projectName: pubspec.name,
+        projectName: metadata.name,
         provider,
         model,
         mode,

--- a/src/mcp-server.js
+++ b/src/mcp-server.js
@@ -8,13 +8,12 @@ import { readFile } from 'node:fs/promises';
 import { resolve, join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { scan } from './scanner.js';
-import { read as readPubspec } from './pubspec-reader.js';
 import { read as readPlist } from './plist-reader.js';
 import { read as readManifest } from './manifest-reader.js';
 import { fetchGuidelines } from './guidelines.js';
 import { audit } from './auditor.js';
-import { loadConfig } from './config.js';
 import { PROVIDER_DEFAULTS, detectPlatform } from './defaults.js';
+import { readProjectMetadata, validateProject } from './project-reader.js';
 import { trackEvent } from './telemetry.js';
 
 // ── Read package version ──
@@ -43,19 +42,6 @@ function resolveConfig(projectDir) {
   return { provider, model, apiKey };
 }
 
-// ── Validate project directory ──
-
-function validateProject(projectDir) {
-  const resolved = resolve(projectDir);
-  if (!existsSync(resolved)) {
-    throw new Error(`Directory not found: ${resolved}`);
-  }
-  if (!existsSync(join(resolved, 'lib'))) {
-    throw new Error(`No lib/ directory found in ${resolved}. Is this a Flutter project?`);
-  }
-  return resolved;
-}
-
 // ── Create server ──
 
 const server = new McpServer({
@@ -67,9 +53,9 @@ const server = new McpServer({
 
 server.tool(
   'shipli_store_audit',
-  'Run a store compliance audit on a Flutter project against Apple App Store and/or Google Play guidelines. Scans Dart source files, pubspec.yaml, Info.plist (iOS), and AndroidManifest.xml (Android). Returns structured JSON with PASS/WARNING/FAIL scores, specific guideline citations, and actionable fix suggestions. Supports both Flutter apps and packages.',
+  'Run a store compliance audit on a Flutter or React Native project against Apple App Store and/or Google Play guidelines. Scans source files plus native permission manifests and returns structured JSON with PASS/WARNING/FAIL scores, guideline citations, and actionable fixes.',
   {
-    projectDir: z.string().describe('Absolute path to the Flutter project root directory. Must contain a pubspec.yaml and a lib/ folder. Example: "/Users/you/projects/my-flutter-app"'),
+    projectDir: z.string().describe('Absolute path to the Flutter or React Native project root directory. Example: "/Users/you/projects/my-mobile-app"'),
     platform: z.enum(['ios', 'android', 'both']).optional().describe('Target platform: "ios" (App Store only), "android" (Play Store only), or "both" (both stores). Auto-detected from ios/ and android/ directory presence if omitted.'),
   },
   async ({ projectDir, platform }) => {
@@ -78,15 +64,15 @@ server.tool(
       const dir = validateProject(projectDir);
       const { provider, model, apiKey } = resolveConfig(dir);
 
-      const pubspec = await readPubspec(dir);
-      const projectType = pubspec.projectType;
+      const metadata = await readProjectMetadata(dir);
+      const projectType = metadata.projectType;
       const resolvedPlatform = platform || detectPlatform(dir);
 
-      const { files } = await scan(dir);
+      const { files } = await scan(dir, { ecosystem: metadata.ecosystem });
 
       let exampleFiles = [];
-      if (projectType === 'package' && existsSync(join(dir, 'example', 'lib'))) {
-        const exampleResult = await scan(join(dir, 'example'));
+      if (projectType === 'package' && metadata.ecosystem === 'flutter' && existsSync(join(dir, 'example', 'lib'))) {
+        const exampleResult = await scan(join(dir, 'example'), { ecosystem: metadata.ecosystem });
         exampleFiles = exampleResult.files;
       }
 
@@ -116,7 +102,7 @@ server.tool(
           exampleFiles,
           permissions: plistData.permissions,
           androidPermissions: manifestData.permissions,
-          pubspec,
+          metadata,
           plistFound: (resolvedPlatform === 'ios' || resolvedPlatform === 'both') ? plistData.found : undefined,
           androidManifestFound: (resolvedPlatform === 'android' || resolvedPlatform === 'both') ? manifestData.found : undefined,
           projectType,
@@ -155,9 +141,9 @@ server.tool(
 
 server.tool(
   'shipli_code_review',
-  'Run a code quality and security review on a Flutter project. Scans all Dart source files and pubspec.yaml. Checks architecture patterns, error handling, performance issues, dependency hygiene, and security vulnerabilities. Returns structured JSON with findings, severity levels, and fix suggestions. Supports both Flutter apps and packages (including example/ directories).',
+  'Run a code quality and security review on a Flutter or React Native project. Scans source files plus project metadata, then checks architecture, error handling, performance issues, dependency hygiene, and security vulnerabilities.',
   {
-    projectDir: z.string().describe('Absolute path to the Flutter project root directory. Must contain a pubspec.yaml and a lib/ folder. Example: "/Users/you/projects/my-flutter-app"'),
+    projectDir: z.string().describe('Absolute path to the Flutter or React Native project root directory. Example: "/Users/you/projects/my-mobile-app"'),
   },
   async ({ projectDir }) => {
     const startTime = Date.now();
@@ -165,14 +151,14 @@ server.tool(
       const dir = validateProject(projectDir);
       const { provider, model, apiKey } = resolveConfig(dir);
 
-      const pubspec = await readPubspec(dir);
-      const projectType = pubspec.projectType;
+      const metadata = await readProjectMetadata(dir);
+      const projectType = metadata.projectType;
 
-      const { files } = await scan(dir);
+      const { files } = await scan(dir, { ecosystem: metadata.ecosystem });
 
       let exampleFiles = [];
-      if (projectType === 'package' && existsSync(join(dir, 'example', 'lib'))) {
-        const exampleResult = await scan(join(dir, 'example'));
+      if (projectType === 'package' && metadata.ecosystem === 'flutter' && existsSync(join(dir, 'example', 'lib'))) {
+        const exampleResult = await scan(join(dir, 'example'), { ecosystem: metadata.ecosystem });
         exampleFiles = exampleResult.files;
       }
 
@@ -182,7 +168,7 @@ server.tool(
           exampleFiles,
           permissions: {},
           androidPermissions: [],
-          pubspec,
+          metadata,
           plistFound: undefined,
           androidManifestFound: undefined,
           projectType,

--- a/src/package-reader.js
+++ b/src/package-reader.js
@@ -1,0 +1,41 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+function isReactNativePackage(pkg) {
+  const deps = {
+    ...(pkg.dependencies || {}),
+    ...(pkg.devDependencies || {}),
+    ...(pkg.peerDependencies || {}),
+  };
+
+  return Boolean(deps['react-native'] || deps.expo);
+}
+
+export async function read(projectDir) {
+  const packagePath = path.join(projectDir, 'package.json');
+
+  try {
+    const content = await readFile(packagePath, 'utf-8');
+    const pkg = JSON.parse(content);
+
+    if (!isReactNativePackage(pkg)) {
+      throw new Error('package.json found, but no react-native or expo dependency is declared.');
+    }
+
+    return {
+      name: pkg.name || 'unknown',
+      version: pkg.version || null,
+      description: pkg.description || null,
+      dependencies: Object.keys(pkg.dependencies || {}),
+      devDependencies: Object.keys(pkg.devDependencies || {}),
+      scripts: Object.keys(pkg.scripts || {}),
+      projectType: 'app',
+      ecosystem: 'react-native',
+    };
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      throw new Error('package.json not found. Is this a React Native project?');
+    }
+    throw err;
+  }
+}

--- a/src/plist-reader.js
+++ b/src/plist-reader.js
@@ -1,11 +1,23 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 import plist from 'plist';
+import fg from 'fast-glob';
 
 export async function read(projectDir) {
-  const plistPath = path.join(projectDir, 'ios', 'Runner', 'Info.plist');
+  const candidates = [
+    path.join(projectDir, 'ios', 'Runner', 'Info.plist'),
+    ...(await fg.glob('ios/**/Info.plist', {
+      cwd: projectDir,
+      absolute: true,
+      ignore: ['**/Pods/**', '**/build/**'],
+    })),
+  ];
+  const plistPath = candidates[0];
 
   try {
+    if (!plistPath) {
+      return { found: false, permissions: {}, bundleId: null };
+    }
     const xml = await readFile(plistPath, 'utf-8');
     const parsed = plist.parse(xml);
 

--- a/src/project-reader.js
+++ b/src/project-reader.js
@@ -1,0 +1,34 @@
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { read as readPackage } from './package-reader.js';
+import { read as readPubspec } from './pubspec-reader.js';
+
+export function validateProject(projectDir) {
+  const resolved = resolve(projectDir);
+  const hasPubspec = existsSync(join(resolved, 'pubspec.yaml'));
+  const hasPackageJson = existsSync(join(resolved, 'package.json'));
+
+  if (!hasPubspec && !hasPackageJson) {
+    throw new Error(`No pubspec.yaml or package.json found in ${resolved}. Shipli currently supports Flutter and React Native projects.`);
+  }
+
+  if (hasPubspec && !existsSync(join(resolved, 'lib'))) {
+    throw new Error(`No lib/ directory found in ${resolved}. Is this a Flutter project?`);
+  }
+
+  return resolved;
+}
+
+export async function readProjectMetadata(projectDir) {
+  const resolved = resolve(projectDir);
+
+  if (existsSync(join(resolved, 'pubspec.yaml'))) {
+    return readPubspec(resolved);
+  }
+
+  if (existsSync(join(resolved, 'package.json'))) {
+    return readPackage(resolved);
+  }
+
+  throw new Error(`No supported project metadata found in ${resolved}.`);
+}

--- a/src/pubspec-reader.js
+++ b/src/pubspec-reader.js
@@ -19,6 +19,7 @@ export async function read(projectDir) {
       dependencies: Object.keys(doc.dependencies || {}),
       devDependencies: Object.keys(doc.dev_dependencies || {}),
       projectType: isPlugin ? 'package' : 'app',
+      ecosystem: 'flutter',
       pluginPlatforms: isPlugin ? (flutterSection.plugin.platforms || null) : null,
     };
   } catch (err) {

--- a/src/scanner.js
+++ b/src/scanner.js
@@ -5,7 +5,7 @@ import fg from 'fast-glob';
 const MAX_LINES_PER_FILE = 300;
 const MAX_TOTAL_LINES = 8000;
 
-const STRUCTURAL_KEYWORDS = [
+const FLUTTER_STRUCTURAL_KEYWORDS = [
   'class ', 'extends ', 'implements ', 'mixin ', 'enum ', 'abstract ',
   'typedef ', 'sealed ', 'factory ', 'const ', 'final ', 'static ',
   'required ', 'late ', 'part ', 'part of ',
@@ -13,7 +13,7 @@ const STRUCTURAL_KEYWORDS = [
   'library ',
 ];
 
-const ANNOTATION_PATTERNS = [
+const FLUTTER_ANNOTATION_PATTERNS = [
   '@override', '@required', '@immutable', '@pragma', '@visibleForTesting',
   '@freezed', '@JsonSerializable', '@riverpod', '@injectable',
   '@protected', '@mustCallSuper', '@Deprecated', '@experimental',
@@ -22,72 +22,49 @@ const ANNOTATION_PATTERNS = [
   '@GenerateMocks', '@singleton', '@lazySingleton', '@module',
 ];
 
-const SIGNAL_PATTERNS = [
-  // Widget build & state
+const FLUTTER_SIGNAL_PATTERNS = [
   'Widget build', 'State<', 'StatefulWidget', 'StatelessWidget',
   'ChangeNotifier', 'notifyListeners', 'setState',
-  // Navigation & routing
   'Navigator', 'GoRouter', 'AutoRouter',
   'MaterialPageRoute', 'CupertinoPageRoute', 'PageRouteBuilder',
   'GoRoute', 'RouteBase', 'onGenerateRoute', 'onUnknownRoute',
   'pushNamed', 'pushReplacementNamed',
-  // State management
   'Provider', 'Bloc', 'Cubit', 'GetX', 'Riverpod', 'ConsumerWidget',
-  // Networking
   'http.', 'dio.', 'Dio(', 'ApiClient',
   'baseUrl', 'BASE_URL', 'apiUrl', 'API_URL',
   'Authorization', 'Bearer ',
-  // Storage
   'SharedPreferences', 'Hive', 'sqflite', 'drift',
   'SecureStorage', 'FlutterSecureStorage',
-  // Firebase
   'FirebaseAuth', 'FirebaseMessaging', 'FirebaseAnalytics', 'Crashlytics',
-  // Permissions & hardware
   'permission', 'Permission', 'camera', 'Camera',
   'location', 'Location', 'Geolocator',
   'image_picker', 'ImagePicker', 'PhotoView',
   'Clipboard',
-  // URLs & deep links
   'url_launcher', 'launchUrl', 'canLaunchUrl',
-  // WebView
   'webview', 'WebView', 'InAppWebView',
-  // Purchases
   'in_app_purchase', 'StoreKit', 'InAppPurchase',
-  // Platform
   'Platform.is', 'kIsWeb',
   'MethodChannel', 'EventChannel', 'BasicMessageChannel',
   'PlatformException',
-  // Notifications
   'NotificationService', 'LocalNotification', 'FlutterLocalNotifications',
-  // Auth & biometrics
   'BiometricAuth', 'LocalAuthentication',
-  // UI structure
   'Scaffold', 'AppBar', 'BottomNavigationBar', 'TabBar', 'Drawer',
   'MaterialApp', 'CupertinoApp',
   'showDialog', 'showModalBottomSheet', 'AlertDialog',
   'TextEditingController', 'FormField', 'Form(',
   'ListView', 'GridView', 'CustomScrollView',
-  // Lifecycle
   'initState', 'dispose', 'didChangeDependencies', 'didUpdateWidget',
   'WidgetsBindingObserver', 'didChangeAppLifecycleState',
-  // Error handling
   'try {', 'catch (', 'on Exception', 'on Error',
   'FlutterError', 'ErrorWidget', 'runZonedGuarded',
-  // Crypto & security
   'encrypt', 'decrypt',
-  // Tracking & analytics
   'Analytics', 'Tracker', 'Sentry',
   'AppTrackingTransparency',
-  // Background & isolates
   'Isolate', 'compute(',
   'BackgroundFetch', 'WorkManager',
-  // Code push (forbidden by Apple)
   'CodePush', 'shorebird',
-  // FFI
   'DynamicLibrary',
-  // Health
   'HealthKit', 'health',
-  // Android-specific
   'google_mobile_ads', 'GoogleMobileAds',
   'play_billing', 'BillingClient',
   'targetSdkVersion', 'minSdkVersion',
@@ -95,13 +72,42 @@ const SIGNAL_PATTERNS = [
   'FlutterActivity', 'FlutterFragmentActivity',
   'google_sign_in', 'GoogleSignIn',
   'firebase_core', 'FirebaseCore',
-  // Misc
   'openUrl', 'open(',
 ];
 
-// Patterns that should match against the RAW line (including string contents)
-// because URLs inside strings are the actual security signal
+const REACT_NATIVE_STRUCTURAL_KEYWORDS = [
+  'function ', 'class ', 'const ', 'let ', 'export ', 'import ',
+  'async function ', 'interface ', 'type ', 'enum ',
+  'useState(', 'useEffect(', 'useMemo(', 'useCallback(', 'useRef(',
+  'return (', 'createContext(', 'memo(', 'forwardRef(',
+];
+
+const REACT_NATIVE_SIGNAL_PATTERNS = [
+  "from 'react-native'", 'from "react-native"',
+  "from 'expo'", 'from "expo"',
+  'NavigationContainer', 'createNativeStackNavigator', 'createBottomTabNavigator',
+  'useNavigation', 'useRoute', 'Stack.Screen', 'Tab.Screen',
+  'StyleSheet.create', 'SafeAreaView', 'KeyboardAvoidingView',
+  'ScrollView', 'FlatList', 'SectionList', 'VirtualizedList',
+  'Animated.', 'Reanimated', 'GestureHandlerRootView',
+  'AsyncStorage', 'MMKV', 'SecureStore', 'Keychain',
+  'fetch(', 'axios.', 'axios(', 'queryClient', 'useQuery(', 'useMutation(',
+  'Linking.', 'DeepLink', 'UniversalLink', 'AppState',
+  'PermissionsAndroid', 'react-native-permissions',
+  'NativeModules', 'NativeEventEmitter', 'TurboModuleRegistry',
+  'expo-notifications', 'PushNotification', 'messaging()',
+  'react-hook-form', 'Formik', 'Yup', 'zod',
+  'redux', 'zustand', 'mobx', 'jotai',
+  'useColorScheme', 'Appearance.', 'Platform.OS',
+  'TouchableOpacity', 'Pressable', 'Modal', 'Alert.alert',
+  'WebView', 'expo-web-browser',
+  'react-native-iap', 'RevenueCat', 'AdMob',
+  'CodePush', 'expo-updates',
+  'Clipboard', 'CameraRoll', 'ImagePicker', 'launchImageLibrary',
+];
+
 const RAW_LINE_PATTERNS = ['http://', 'https://'];
+const DART_SIG_PATTERN = /^\s*(?:[\w<>?,\[\]\s]+)\s+\w+\s*\(/;
 
 function stripStringLiterals(line) {
   return line
@@ -109,40 +115,76 @@ function stripStringLiterals(line) {
     .replace(/'(?:[^'\\]|\\.)*'/g, "''");
 }
 
-const SIG_PATTERN = /^\s*(?:[\w<>?,\[\]\s]+)\s+\w+\s*\(/;
+function ecosystemConfig(ecosystem) {
+  if (ecosystem === 'react-native') {
+    return {
+      patterns: [
+        'App.{js,jsx,ts,tsx}',
+        'index.{js,jsx,ts,tsx}',
+        'src/**/*.{js,jsx,ts,tsx}',
+        'app/**/*.{js,jsx,ts,tsx}',
+        'components/**/*.{js,jsx,ts,tsx}',
+        'screens/**/*.{js,jsx,ts,tsx}',
+        'navigation/**/*.{js,jsx,ts,tsx}',
+        'hooks/**/*.{js,jsx,ts,tsx}',
+        'services/**/*.{js,jsx,ts,tsx}',
+        'store/**/*.{js,jsx,ts,tsx}',
+        'context/**/*.{js,jsx,ts,tsx}',
+        'utils/**/*.{js,jsx,ts,tsx}',
+      ],
+      ignore: [
+        '**/node_modules/**',
+        '**/dist/**',
+        '**/build/**',
+        '**/.expo/**',
+        '**/coverage/**',
+      ],
+      structuralKeywords: REACT_NATIVE_STRUCTURAL_KEYWORDS,
+      annotationPatterns: [],
+      signalPatterns: REACT_NATIVE_SIGNAL_PATTERNS,
+      emptyError: 'No JavaScript/TypeScript files found in typical React Native app locations',
+    };
+  }
 
-function isSignificantLine(line) {
+  return {
+    patterns: ['lib/**/*.dart'],
+    ignore: ['**/generated/**', '**/*.g.dart', '**/*.freezed.dart'],
+    structuralKeywords: FLUTTER_STRUCTURAL_KEYWORDS,
+    annotationPatterns: FLUTTER_ANNOTATION_PATTERNS,
+    signalPatterns: FLUTTER_SIGNAL_PATTERNS,
+    emptyError: 'No .dart files found in lib/ directory',
+  };
+}
+
+function isSignificantLine(line, config, ecosystem) {
   const stripped = stripStringLiterals(line);
 
-  for (const kw of STRUCTURAL_KEYWORDS) {
+  for (const kw of config.structuralKeywords) {
     if (stripped.includes(kw)) return true;
   }
-  for (const ann of ANNOTATION_PATTERNS) {
+  for (const ann of config.annotationPatterns) {
     if (stripped.includes(ann)) return true;
   }
-  for (const sig of SIGNAL_PATTERNS) {
-    if (stripped.includes(sig)) return true;
+  for (const sig of config.signalPatterns) {
+    if (line.includes(sig) || stripped.includes(sig)) return true;
   }
-  // URL patterns checked against raw line — URLs in strings ARE the signal
   for (const pat of RAW_LINE_PATTERNS) {
     if (line.includes(pat)) return true;
   }
 
-  // Method/function signatures
-  if (SIG_PATTERN.test(stripped)) {
-    // Single-line complete signature (handles async, async*, sync* variants)
-    if (/[\{=]/.test(stripped.slice(-5)) || stripped.endsWith(';')) return true;
-    // Multi-line signature start (line ends with open paren or has trailing comma)
-    if (stripped.endsWith('(') || stripped.endsWith(',')) return true;
-  }
+  if (ecosystem === 'flutter') {
+    if (DART_SIG_PATTERN.test(stripped)) {
+      if (/[\{=]/.test(stripped.slice(-5)) || stripped.endsWith(';')) return true;
+      if (stripped.endsWith('(') || stripped.endsWith(',')) return true;
+    }
 
-  // Closing braces at class level
-  if (/^}\s*$/.test(line)) return true;
+    if (/^}\s*$/.test(line)) return true;
+  }
 
   return false;
 }
 
-function extractSkeleton(lines) {
+function extractSkeleton(lines, config, ecosystem) {
   const result = [];
   let inBlockComment = false;
   let inMultiLineSig = false;
@@ -160,10 +202,7 @@ function extractSkeleton(lines) {
     }
     if (!line) continue;
     if (line.startsWith('//')) continue;
-    if (line.startsWith('import ')) continue;
-    if (line.startsWith('export ')) continue;
 
-    // If accumulating a multi-line signature, keep lines until it closes
     if (inMultiLineSig) {
       result.push(raw.replace(/\s+$/, ''));
       if (line.includes(') {') || line.includes(') async {') || line.includes(') async* {')
@@ -173,10 +212,9 @@ function extractSkeleton(lines) {
       continue;
     }
 
-    if (isSignificantLine(line)) {
+    if (isSignificantLine(line, config, ecosystem)) {
       result.push(raw.replace(/\s+$/, ''));
-      // Detect start of multi-line signature (ends with open paren)
-      if (SIG_PATTERN.test(stripStringLiterals(line)) && line.trimEnd().endsWith('(')) {
+      if (ecosystem === 'flutter' && DART_SIG_PATTERN.test(stripStringLiterals(line)) && line.trimEnd().endsWith('(')) {
         inMultiLineSig = true;
       }
     }
@@ -185,15 +223,18 @@ function extractSkeleton(lines) {
   return result;
 }
 
-export async function scan(projectDir) {
-  const entries = await fg.glob('lib/**/*.dart', {
+export async function scan(projectDir, options = {}) {
+  const ecosystem = options.ecosystem || 'flutter';
+  const config = ecosystemConfig(ecosystem);
+
+  const entries = await fg.glob(config.patterns, {
     cwd: projectDir,
     absolute: true,
-    ignore: ['**/generated/**', '**/*.g.dart', '**/*.freezed.dart'],
+    ignore: config.ignore,
   });
 
   if (entries.length === 0) {
-    throw new Error('No .dart files found in lib/ directory');
+    throw new Error(config.emptyError);
   }
 
   const files = [];
@@ -205,7 +246,7 @@ export async function scan(projectDir) {
     const lines = content.split('\n');
     totalLines += lines.length;
 
-    let skeleton = extractSkeleton(lines);
+    let skeleton = extractSkeleton(lines, config, ecosystem);
 
     if (skeleton.length > MAX_LINES_PER_FILE) {
       const truncated = skeleton.length - MAX_LINES_PER_FILE;
@@ -218,7 +259,6 @@ export async function scan(projectDir) {
     files.push({ relativePath, skeleton: skeleton.join('\n') });
   }
 
-  // Proportional truncation if total exceeds limit
   if (skeletonLines > MAX_TOTAL_LINES) {
     const ratio = MAX_TOTAL_LINES / skeletonLines;
     for (const file of files) {

--- a/tests/project-support.test.js
+++ b/tests/project-support.test.js
@@ -1,0 +1,90 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtemp, mkdir, writeFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { readProjectMetadata, validateProject } from '../src/project-reader.js';
+import { scan } from '../src/scanner.js';
+
+async function withTempProject(setupFn) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'shipli-test-'));
+  try {
+    await setupFn(dir);
+    return dir;
+  } catch (error) {
+    await rm(dir, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+test('readProjectMetadata detects a React Native app from package.json', async (t) => {
+  const dir = await withTempProject(async (projectDir) => {
+    await writeFile(path.join(projectDir, 'package.json'), JSON.stringify({
+      name: 'rn-app',
+      version: '1.0.0',
+      dependencies: {
+        react: '^19.0.0',
+        'react-native': '^0.81.0',
+      },
+      scripts: {
+        start: 'react-native start',
+      },
+    }, null, 2));
+  });
+
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+
+  const validated = validateProject(dir);
+  const metadata = await readProjectMetadata(validated);
+
+  assert.equal(metadata.ecosystem, 'react-native');
+  assert.equal(metadata.projectType, 'app');
+  assert.deepEqual(metadata.scripts, ['start']);
+});
+
+test('scan captures React Native JS/TS files from standard app locations', async (t) => {
+  const dir = await withTempProject(async (projectDir) => {
+    await writeFile(path.join(projectDir, 'package.json'), JSON.stringify({
+      name: 'rn-app',
+      version: '1.0.0',
+      dependencies: {
+        react: '^19.0.0',
+        'react-native': '^0.81.0',
+      },
+    }, null, 2));
+    await mkdir(path.join(projectDir, 'src', 'screens'), { recursive: true });
+    await writeFile(path.join(projectDir, 'App.tsx'), [
+      "import React from 'react';",
+      "import { View, Text, StyleSheet } from 'react-native';",
+      '',
+      'export function App() {',
+      '  return (',
+      '    <View>',
+      '      <Text>Hello</Text>',
+      '    </View>',
+      '  );',
+      '}',
+      '',
+      'const styles = StyleSheet.create({});',
+      '',
+    ].join('\n'));
+    await writeFile(path.join(projectDir, 'src', 'screens', 'HomeScreen.tsx'), [
+      "import { useNavigation } from '@react-navigation/native';",
+      'export const HomeScreen = () => {',
+      '  const navigation = useNavigation();',
+      '  return null;',
+      '};',
+      '',
+    ].join('\n'));
+  });
+
+  t.after(async () => rm(dir, { recursive: true, force: true }));
+
+  const result = await scan(dir, { ecosystem: 'react-native' });
+
+  assert.equal(result.stats.totalFiles, 2);
+  assert.ok(result.files.some((file) => file.relativePath === 'App.tsx'));
+  assert.ok(result.files.some((file) => file.relativePath === path.join('src', 'screens', 'HomeScreen.tsx')));
+  assert.ok(result.files.some((file) => file.skeleton.includes('StyleSheet.create')));
+  assert.ok(result.files.some((file) => file.skeleton.includes('useNavigation')));
+});


### PR DESCRIPTION
## What this changes

This PR adds first-pass React Native support to Shipli so React Native projects can be audited alongside existing Flutter support.

## Included

- React Native project detection from `package.json`
- scanning for common React Native `js` / `jsx` / `ts` / `tsx` app paths
- native metadata support for iOS `Info.plist` and Android `AndroidManifest.xml`
- prompt and evidence updates so audits stop assuming every project is Flutter
- CLI, MCP, package metadata, and README updates to reflect React Native support
- test coverage for React Native metadata detection and scanning

## Verification

```bash
npm test
node src/index.js --help
node src/mcp-server.js
```

Closes #1